### PR TITLE
fix: missing forward slash and add pattern

### DIFF
--- a/config/templates/tomcat/tomcat.json
+++ b/config/templates/tomcat/tomcat.json
@@ -8,7 +8,7 @@
     "startTomcatParserRegex": "/^\\d{2}-\\w{3}-\\d{4}\\s\\d{2}:\\d{2}:\\d{2}.\\d{3}.*$/",
     "contTomcatParserRegex": "/^[ \\t+].*|Caused by.*/",
     "startAppParserRegex": "/^\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}(.\\d{3}?).*$/",
-    "contAppParserRegex": "/^[ \\t+a-zA-Z{}\\/\\[\\]].*"
+    "contAppParserRegex": "/^[ \\t+a-zA-Z{}\\/\\[\\]].*|^[a-zA-Z].*/"
   },
   "files": [
     { "tmpl": "filter/filters.conf.njk", "type": "filter"},


### PR DESCRIPTION
I missed the ending forward slash in a previous commit, so the multiline parsing wasn't working. I also added an extra match pattern.