### PR TITLE
fix: rename message_parsed to message

### DIFF
--- a/config/templates/filters.conf.njk
+++ b/config/templates/filters.conf.njk
@@ -7,8 +7,6 @@
     Add ecs.version 1.12.0
     Rename level log.level
     Rename event_sequence event.sequence
-    Rename message event.original
-    Rename message_parsed message
 
 {% for typeTag in measureTypes.historic -%}
 {{ lua.renderLua(typeTag, 'timestamp.lua', 'append_event_created') }}

--- a/config/templates/filters.conf.njk
+++ b/config/templates/filters.conf.njk
@@ -8,6 +8,7 @@
     Rename level log.level
     Rename event_sequence event.sequence
     Rename message event.original
+    Rename message_parsed message
 
 {% for typeTag in measureTypes.historic -%}
 {{ lua.renderLua(typeTag, 'timestamp.lua', 'append_event_created') }}

--- a/config/templates/tomcat/filter/filters.conf.njk
+++ b/config/templates/tomcat/filter/filters.conf.njk
@@ -87,3 +87,5 @@
     Add service.name {{ component | lower }}
     Add service.environment {{ environment }}
     Add @metadata.keyAsPath true
+    Rename message event.original
+    Rename message_parsed message


### PR DESCRIPTION
The message data wasn't being sent. so I added the missing rename rule to the filters.conf so the message_parsed key gets renamed to message.    