### PR TITLE
feat: handle any char between date and time

### DIFF
--- a/config/templates/tomcat/tomcat.json
+++ b/config/templates/tomcat/tomcat.json
@@ -7,7 +7,7 @@
     "!logs_path_app": "{{ localLogsPathPrefix | default('/apps_ux/logs') }}/{{ app | upper }}/{{ component | lower }}/{{ component | lower }}.log",
     "startTomcatParserRegex": "/^\\d{2}-\\w{3}-\\d{4}\\s\\d{2}:\\d{2}:\\d{2}.\\d{3}.*$/",
     "contTomcatParserRegex": "/^[ \\t+a-zA-Z].*|Caused by.*/",
-    "startAppParserRegex": "/^\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}(.\\d{3}?).*$/",
+    "startAppParserRegex": "/^\\d{4}-\\d{2}-\\d{2}.\\d{2}:\\d{2}:\\d{2}(?:.\\d{3}?).*$/",
     "contAppParserRegex": "/^[ \\t+a-zA-Z{}\\/\\[\\]].*/"
   },
   "files": [


### PR DESCRIPTION
The original start regex only handled any whitespace character, but some logs have other characters as a separator. I replaced the \s with a period. I also made a group non-capturing.