### PR TITLE
Fix Windows agent log path

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -2,7 +2,7 @@
   "context": {
     "appPathJq": "/sw_ux/bin/jq",
     "fluentLogLevel": "info",
-    "!fluentLogFile": "{{ 'E:' if os === 'Windows_NT'}}/apps_ux/logs/agents/fluent-bit/fluent-bit.{{agentCount}}.log",
+    "!fluentLogFile": "{{ 'E:/apps_nt' if os === 'Windows_NT' else '/apps_ux'}}/logs/agents/fluent-bit/fluent-bit.{{agentCount}}.log",
     "!inputDbFile": "{{ 'E:' if os === 'Windows_NT'}}/apps_data/agents/fluent-bit/fluent-bit-logs.db",
     "inputTailMemBufLimit": "5MB",
     "inputTailIgnoreOlder": "7d",


### PR DESCRIPTION
The path for Windows agent logs was being generated with an incorrect location