### PR TITLE
Add fluentbit basic metrics to GIMLET & MOJITO - ISSS wso2 servers

### DIFF
--- a/config/server/gimlet.json
+++ b/config/server/gimlet.json
@@ -1,0 +1,16 @@
+{
+  "address": "gimlet.bcgov",
+  "proxy": "http://test-forwardproxy.nrs.bcgov:23128",
+  "os": "linux",
+  "vault_cd_user_field": "username_lowercase",
+  "vault_cd_pass_field": "password",
+  "vault_cd_path": "groups/appdelivery/jenkins-isss-cdua",
+  "apps": [
+    {"id": "cpu", "type": "metric_host_cpu", "context": {}},
+    {"id": "disk", "type": "metric_host_disk", "context": {}},
+    {"id": "disk_named", "type": "metric_host_disk_named", "context": {}},
+    {"id": "memory", "type": "metric_host_memory", "context": {}},
+    {"id": "network", "type": "metric_host_network", "context": {}}
+  ],
+  "context": {}
+}

--- a/config/server/mojito.json
+++ b/config/server/mojito.json
@@ -1,0 +1,16 @@
+{
+  "address": "mojito.bcgov",
+  "proxy": "http://forwardproxy.nrs.bcgov:23128",
+  "os": "linux",
+  "vault_cd_user_field": "username_lowercase",
+  "vault_cd_pass_field": "password",
+  "vault_cd_path": "groups/appdelivery/jenkins-isss-cdua",
+  "apps": [
+    {"id": "cpu", "type": "metric_host_cpu", "context": {}},
+    {"id": "disk", "type": "metric_host_disk", "context": {}},
+    {"id": "disk_named", "type": "metric_host_disk_named", "context": {}},
+    {"id": "memory", "type": "metric_host_memory", "context": {}},
+    {"id": "network", "type": "metric_host_network", "context": {}}
+  ],
+  "context": {}
+}


### PR DESCRIPTION
Adding configurations for GIMLET/MOJITO to deploy basic fluentbit metric collection for these servers. 