### PR TITLE
Remove custom regex for test and prod

### DIFF
--- a/config/server/cocacola.json
+++ b/config/server/cocacola.json
@@ -106,10 +106,7 @@
         "type": "tomcat",
         "context": {
           "app": "CIRRAS",
-          "component": "cirras-policies-api",
-          "startAppParserRegex": "/^\\[\\d{4}-\\d{2}-\\d{2}.\\d{2}:\\d{2}:\\d{2}(?:.\\d{3}?).*$/",
-          "contAppParserRegex": "/^(?:\\[\\D|[^\\[]).*/",
-          "appParserFilterRegex": "(?m)^\\[(?<tomcat_time>\\d{4}-\\d{2}-\\d{2}.\\d{2}:\\d{2}:\\d{2}(.\\d{3})?)\\](\\s+)\\[(?<level>\\w+)\\s*\\][\\s:]*(?<message_parsed>.*)"
+          "component": "cirras-policies-api"
         }
       },
       {

--- a/config/server/drpepper.json
+++ b/config/server/drpepper.json
@@ -114,10 +114,7 @@
         "type": "tomcat",
         "context": {
           "app": "CIRRAS",
-          "component": "cirras-policies-api",
-          "startAppParserRegex": "/^\\[\\d{4}-\\d{2}-\\d{2}.\\d{2}:\\d{2}:\\d{2}(?:.\\d{3}?).*$/",
-          "contAppParserRegex": "/^(?:\\[\\D|[^\\[]).*/",
-          "appParserFilterRegex": "(?m)^\\[(?<tomcat_time>\\d{4}-\\d{2}-\\d{2}.\\d{2}:\\d{2}:\\d{2}(.\\d{3})?)\\](\\s+)\\[(?<level>\\w+)\\s*\\][\\s:]*(?<message_parsed>.*)"
+          "component": "cirras-policies-api"
         }
       },
       {


### PR DESCRIPTION
The log format for test and prod works with the standard regex, so the overrides must be removed.