### PR TITLE
Fix cirras-policies-api (remove custom regex for delivery)

### DIFF
--- a/config/server/anomoly.json
+++ b/config/server/anomoly.json
@@ -130,10 +130,7 @@
       "type": "tomcat",
       "context": {
         "app": "CIRRAS",
-        "component": "cirras-policies-api",
-        "startAppParserRegex": "/^\\[\\d{4}-\\d{2}-\\d{2}.\\d{2}:\\d{2}:\\d{2}(?:.\\d{3}?).*$/",
-        "contAppParserRegex": "/^(?:\\[\\D|[^\\[]).*/",
-        "appParserFilterRegex": "(?m)^\\[(?<tomcat_time>\\d{4}-\\d{2}-\\d{2}.\\d{2}:\\d{2}:\\d{2}(.\\d{3})?)\\](\\s+)\\[(?<level>\\w+)\\s*\\][\\s:]*(?<message_parsed>.*)"
+        "component": "cirras-policies-api"
       }
     },
     {


### PR DESCRIPTION
It appears that the logging for delivery now uses the normal logging form and we need to remove the custom regex