### PR TITLE
feat: downgrade agent to 3.1.7

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -29,5 +29,5 @@
     { "tmpl": "parsers.conf.njk" },
     { "tmpl": "timestamp.lua" }
   ],
-  "fluentBitRelease": "3.2.1"
+  "fluentBitRelease": "3.1.7"
 }


### PR DESCRIPTION
3.1.8 may have introduced a bug in the tail plugin that causes agents to reprocess log entries that should be ignored.